### PR TITLE
Workflow job rename and changelog exclusion

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,8 @@ version-resolver:
     labels:
       - 'patch'
   default: patch
+exclude-labels:
+  - 'skip-changelog'
 template: |
   ## Changelog
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 jobs:
-  plan:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adds:
 - `skip-changelog` label to exclude certain PRs in release notes.

Changes:
 - `plan` -> `check` in the PR workflow as terraform use here is just for formatting and validation.