### PR TITLE
chore: harden GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       day: "friday"
       time: "08:00"
       timezone: "Australia/Perth"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
+    name: Check Terraform
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,17 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: rsclarke/setup-tenv@3d18295597c070746e3af675a40415f65359a411 # v2.1.0
         with:
           tool: terraform

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: zizmor
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # Required for zizmor-action to upload SARIF to GitHub code scanning.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
Hardened the repository's GitHub Actions surface and added ongoing zizmor auditing for pull requests and pushes to main.

- CI workflow: added explicit default-deny permissions, job-level contents read permission, checkout credential persistence disabled, job naming, and concurrency cancellation for stale runs.
- Dependabot: added a seven-day cooldown for GitHub Actions updates.
- zizmor workflow: added a pinned zizmor-action workflow with least-privilege permissions and SARIF upload permission documented for GitHub code scanning.

Validation:
- `zizmor --collect=workflows --strict-collection .` passed.
- `zizmor --collect=dependabot --strict-collection .` passed.
- `zizmor --strict-collection .` passed.
- `zizmor --persona=auditor .` passed.

Policy decisions:
- Existing action SHA pinning policy was preserved; the new zizmor workflow pins `actions/checkout` to v6.0.3's SHA and `zizmorcore/zizmor-action` to v0.5.6's SHA.
- No inline zizmor ignores were added.
