### PR TITLE
chore(ci): limit zizmor workflow triggers

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,8 +2,12 @@ name: zizmor
 
 on:
   pull_request:
+    paths:
+      - .github/**
   push:
     branches: [main]
+    paths:
+      - .github/**
 
 permissions: {}
 


### PR DESCRIPTION
Limits the zizmor workflow to changes that can affect its audit results. Pull requests and pushes to `main` continue to be covered without running the audit for unrelated Terraform changes.

- Add `.github/**` path filters to pull-request and main-branch push triggers
